### PR TITLE
Add sign up and login pages with localStorage auth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import Clients from './pages/Clients'
 import Projects from './pages/Projects'
 import Learning from './pages/Learning'
 import Profile from './pages/Profile'
+import Login from './pages/Login'
+import SignUp from './pages/SignUp'
 import './App.css'
 
 export default function App() {
@@ -20,6 +22,8 @@ export default function App() {
           <Route path="/projects" element={<Projects />} />
           <Route path="/learning" element={<Learning />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<SignUp />} />
         </Routes>
       </div>
     </div>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,7 +1,11 @@
+import { useContext } from 'react'
 import { NavLink } from 'react-router-dom'
+import { AuthContext } from '../context/AuthContext'
 import './NavBar.css'
 
 export default function NavBar() {
+  const { user } = useContext(AuthContext)
+
   return (
     <nav className="navbar">
       <h1 className="logo">ECOMSA Social</h1>
@@ -11,7 +15,14 @@ export default function NavBar() {
         <li><NavLink to="/clients">Clients</NavLink></li>
         <li><NavLink to="/projects">Projects</NavLink></li>
         <li><NavLink to="/learning">Learning</NavLink></li>
-        <li><NavLink to="/profile">Profile</NavLink></li>
+        {user ? (
+          <li><NavLink to="/profile">Profile</NavLink></li>
+        ) : (
+          <>
+            <li><NavLink to="/login">Login</NavLink></li>
+            <li><NavLink to="/signup">Sign Up</NavLink></li>
+          </>
+        )}
       </ul>
     </nav>
   )

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,46 @@
+/* eslint react-refresh/only-export-components: off */
+import { createContext, useState, useEffect } from 'react'
+
+export const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('currentUser')
+    if (stored) setUser(JSON.parse(stored))
+  }, [])
+
+  function signup(name, email, password) {
+    const users = JSON.parse(localStorage.getItem('users') || '[]')
+    const newUser = { name, email, password }
+    users.push(newUser)
+    localStorage.setItem('users', JSON.stringify(users))
+    localStorage.setItem('currentUser', JSON.stringify(newUser))
+    setUser(newUser)
+  }
+
+  function login(email, password) {
+    const users = JSON.parse(localStorage.getItem('users') || '[]')
+    const existing = users.find(
+      u => u.email === email && u.password === password,
+    )
+    if (existing) {
+      localStorage.setItem('currentUser', JSON.stringify(existing))
+      setUser(existing)
+      return true
+    }
+    return false
+  }
+
+  function logout() {
+    localStorage.removeItem('currentUser')
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, signup, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { AuthProvider } from './context/AuthContext'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,39 @@
+import { useState, useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AuthContext } from '../context/AuthContext'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const { login } = useContext(AuthContext)
+  const navigate = useNavigate()
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    const success = login(email, password)
+    if (success) navigate('/profile')
+    else setError('Invalid credentials')
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      {error && <p>{error}</p>}
+      <input
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        placeholder="Password"
+        required
+      />
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,3 +1,16 @@
+import { useContext } from 'react'
+import { Navigate } from 'react-router-dom'
+import { AuthContext } from '../context/AuthContext'
+
 export default function Profile() {
-  return <h2>User Profile - Under Construction</h2>
+  const { user } = useContext(AuthContext)
+  if (!user) return <Navigate to="/login" replace />
+
+  return (
+    <div>
+      <h2>User Profile</h2>
+      <p>Name: {user.name}</p>
+      <p>Email: {user.email}</p>
+    </div>
+  )
 }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,0 +1,43 @@
+import { useState, useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AuthContext } from '../context/AuthContext'
+
+export default function SignUp() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const { signup } = useContext(AuthContext)
+  const navigate = useNavigate()
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    signup(name, email, password)
+    navigate('/profile')
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Sign Up</h2>
+      <input
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Name"
+        required
+      />
+      <input
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        placeholder="Password"
+        required
+      />
+      <button type="submit">Register</button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- implement AuthContext to manage user registration and login via localStorage
- add Sign Up and Login pages with redirects to profile
- protect profile route and update navigation based on login state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890de91f25c8326b57a739c0371330a