### PR TITLE
feat: add editable user profile

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -13,7 +13,15 @@ export function AuthProvider({ children }) {
 
   function signup(name, email, password) {
     const users = JSON.parse(localStorage.getItem('users') || '[]')
-    const newUser = { name, email, password }
+    const newUser = {
+      name,
+      email,
+      password,
+      age: '',
+      position: '',
+      bio: '',
+      photo: '',
+    }
     users.push(newUser)
     localStorage.setItem('users', JSON.stringify(users))
     localStorage.setItem('currentUser', JSON.stringify(newUser))
@@ -38,8 +46,22 @@ export function AuthProvider({ children }) {
     setUser(null)
   }
 
+  function updateProfile(updates) {
+    setUser(prev => {
+      const updated = { ...prev, ...updates }
+      localStorage.setItem('currentUser', JSON.stringify(updated))
+      const users = JSON.parse(localStorage.getItem('users') || '[]')
+      const index = users.findIndex(u => u.email === updated.email)
+      if (index !== -1) {
+        users[index] = updated
+        localStorage.setItem('users', JSON.stringify(users))
+      }
+      return updated
+    })
+  }
+
   return (
-    <AuthContext.Provider value={{ user, signup, login, logout }}>
+    <AuthContext.Provider value={{ user, signup, login, logout, updateProfile }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,16 +1,65 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { AuthContext } from '../context/AuthContext'
 
 export default function Profile() {
-  const { user } = useContext(AuthContext)
+  const { user, updateProfile } = useContext(AuthContext)
+  const [age, setAge] = useState(user?.age || '')
+  const [position, setPosition] = useState(user?.position || '')
+  const [bio, setBio] = useState(user?.bio || '')
+  const [photo, setPhoto] = useState(user?.photo || '')
+  const [preview, setPreview] = useState(user?.photo || '')
   if (!user) return <Navigate to="/login" replace />
+
+  function handlePhotoChange(e) {
+    const file = e.target.files[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setPhoto(reader.result.toString())
+        setPreview(reader.result.toString())
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    updateProfile({ age, position, bio, photo })
+  }
 
   return (
     <div>
       <h2>User Profile</h2>
       <p>Name: {user.name}</p>
       <p>Email: {user.email}</p>
+      <form onSubmit={handleSubmit}>
+        {preview && (
+          <img
+            src={preview}
+            alt="Profile"
+            style={{ width: '100px', height: '100px', objectFit: 'cover' }}
+          />
+        )}
+        <input type="file" accept="image/*" onChange={handlePhotoChange} />
+        <input
+          type="number"
+          value={age}
+          onChange={e => setAge(e.target.value)}
+          placeholder="Age"
+        />
+        <input
+          value={position}
+          onChange={e => setPosition(e.target.value)}
+          placeholder="Job Title"
+        />
+        <textarea
+          value={bio}
+          onChange={e => setBio(e.target.value)}
+          placeholder="Short biography"
+        />
+        <button type="submit">Save</button>
+      </form>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expand AuthContext with default profile fields and updateProfile helper
- implement profile editing UI with photo upload and preview

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e12154ac8326afcbc7aaf8aad668