### PR TITLE
feat: add navigation search bar

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -52,3 +52,43 @@
     width: 100%;
   }
 }
+
+.search-bar {
+  position: relative;
+  margin-right: 1rem;
+}
+
+.search-bar input {
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  border: none;
+  width: 200px;
+}
+
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: #fff;
+  color: #000;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  border: 1px solid #ccc;
+  z-index: 1000;
+}
+
+.search-result-item {
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.result-type {
+  font-size: 0.8rem;
+  color: #555;
+}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { AuthContext } from '../context/AuthContext'
 import './NavBar.css'
@@ -6,9 +6,46 @@ import './NavBar.css'
 export default function NavBar() {
   const { user } = useContext(AuthContext)
 
+  const employees = ['Alice Johnson', 'Bob Smith', 'Charlie Brown']
+  const clients = ['Acme Corp', 'Globex Corporation', 'Soylent Corp']
+  const projects = ['Project Alpha', 'Project Beta', 'Project Gamma']
+
+  const [query, setQuery] = useState('')
+
+  const results = query
+    ? [
+        ...employees
+          .filter((name) => name.toLowerCase().includes(query.toLowerCase()))
+          .map((name) => ({ type: 'Employee', name })),
+        ...clients
+          .filter((name) => name.toLowerCase().includes(query.toLowerCase()))
+          .map((name) => ({ type: 'Client', name })),
+        ...projects
+          .filter((name) => name.toLowerCase().includes(query.toLowerCase()))
+          .map((name) => ({ type: 'Project', name })),
+      ]
+    : []
+
   return (
     <nav className="navbar">
       <h1 className="logo">ECOMSA Social</h1>
+      <div className="search-bar">
+        <input
+          type="text"
+          placeholder="Search employees, clients, projects..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        {query && results.length > 0 && (
+          <ul className="search-results">
+            {results.map((result, index) => (
+              <li key={index} className="search-result-item">
+                {result.name} <span className="result-type">({result.type})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
       <ul className="nav-links">
         <li><NavLink to="/" end>Home</NavLink></li>
         <li><NavLink to="/search">Search</NavLink></li>


### PR DESCRIPTION
## Summary
- add static employee/client/project lists and live search filtering
- style navigation search bar with dropdown results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e29c15ac832685936feb27199ef2