### PR TITLE
Add admin role and dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { useContext } from 'react'
 import NavBar from './components/NavBar'
 import Home from './pages/Home'
 import Search from './pages/Search'
@@ -8,9 +9,12 @@ import Learning from './pages/Learning'
 import Profile from './pages/Profile'
 import Login from './pages/Login'
 import SignUp from './pages/SignUp'
+import AdminDashboard from './pages/AdminDashboard'
+import { AuthContext } from './context/AuthContext'
 import './App.css'
 
 export default function App() {
+  const { user } = useContext(AuthContext)
   return (
     <div>
       <NavBar />
@@ -21,6 +25,12 @@ export default function App() {
           <Route path="/clients" element={<Clients />} />
           <Route path="/projects" element={<Projects />} />
           <Route path="/learning" element={<Learning />} />
+          <Route
+            path="/admin"
+            element={
+              user?.role === 'admin' ? <AdminDashboard /> : <Navigate to="/" />
+            }
+          />
           <Route path="/profile" element={<Profile />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -52,6 +52,9 @@ export default function NavBar() {
         <li><NavLink to="/clients">Clients</NavLink></li>
         <li><NavLink to="/projects">Projects</NavLink></li>
         <li><NavLink to="/learning">Learning</NavLink></li>
+        {user?.role === 'admin' && (
+          <li><NavLink to="/admin">Admin</NavLink></li>
+        )}
         {user ? (
           <li><NavLink to="/profile">Profile</NavLink></li>
         ) : (

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,17 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, useState, useEffect } from 'react'
 
+const adminUser = {
+  name: 'Admin',
+  email: 'admin@ecomsa.com',
+  password: 'admin',
+  age: '',
+  position: '',
+  bio: '',
+  photo: '',
+  role: 'admin',
+}
+
 export const AuthContext = createContext(null)
 
 export function AuthProvider({ children }) {
@@ -21,6 +32,7 @@ export function AuthProvider({ children }) {
       position: '',
       bio: '',
       photo: '',
+      role: 'employee',
     }
     users.push(newUser)
     localStorage.setItem('users', JSON.stringify(users))
@@ -29,6 +41,16 @@ export function AuthProvider({ children }) {
   }
 
   function login(email, password) {
+    if (email === adminUser.email && password === adminUser.password) {
+      localStorage.setItem('currentUser', JSON.stringify(adminUser))
+      const users = JSON.parse(localStorage.getItem('users') || '[]')
+      if (!users.find(u => u.email === adminUser.email)) {
+        users.push(adminUser)
+        localStorage.setItem('users', JSON.stringify(users))
+      }
+      setUser(adminUser)
+      return true
+    }
     const users = JSON.parse(localStorage.getItem('users') || '[]')
     const existing = users.find(
       u => u.email === email && u.password === password,

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -1,0 +1,3 @@
+export default function AdminDashboard() {
+  return <h2>Admin Dashboard - Restricted Access</h2>
+}


### PR DESCRIPTION
## Summary
- implement basic role system with hardcoded admin user
- show Admin dashboard link and route only for admins
- add minimal Admin Dashboard page

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e4ec7c748326ba39e9368af1c1fc